### PR TITLE
Creates basic rest-api for chords

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 AudioLazy == 0.6
 Flask == 1.0.2
+Flask-RESTful == 0.3.7
+Flask-jsonpify == 1.5.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,17 @@
+from flask import Flask
+from flask_restful import Resource, Api
+from flask_jsonpify import jsonify
+
+from services.dummy_function import get_chord_probabilities
+
+app = Flask(__name__)
+api = Api(app)
+
+class NextChord(Resource):
+    def get(self, chord):
+        return jsonify(get_chord_probabilities(chord))
+
+api.add_resource(NextChord, "/next/<chord>")
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/services/dummy_function.py
+++ b/services/dummy_function.py
@@ -1,0 +1,2 @@
+def get_chord_probabilities(chord):
+    return {"C6" : .5, "C7" : .25, "C*" : .25}


### PR DESCRIPTION
To make a request to the API: `/next/<chord>`

Will be modified if needed after the statistical analysis is complete

Resolves issue #8 